### PR TITLE
Deprecated function in PHP 7.4

### DIFF
--- a/lib/PayPal/IPN/PPIPNMessage.php
+++ b/lib/PayPal/IPN/PPIPNMessage.php
@@ -81,11 +81,7 @@ class PPIPNMessage
             return $this->isIpnVerified;
         } else {
             $request = self::IPN_CMD;
-            if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc() == 1) {
-                $get_magic_quotes_exists = true;
-            } else {
-                $get_magic_quotes_exists = false;
-            }
+            $get_magic_quotes_exists = false;
             foreach ($this->ipnData as $key => $value) {
                 if ($get_magic_quotes_exists) {
                     $value = urlencode(stripslashes($value));


### PR DESCRIPTION
Function get_magic_quotes_gpc is deprecated in PHP 7.4: 

https://stackoverflow.com/questions/61054418/php-7-4-deprecated-get-magic-quotes-gpc-function-alternative