### PR TITLE
Fix required parameters deprecation warning

### DIFF
--- a/lib/PayPal/Core/PPHttpConfig.php
+++ b/lib/PayPal/Core/PPHttpConfig.php
@@ -217,7 +217,7 @@ class PPHttpConfig
      *
      * @return array
      */
-    public function getHttpConstantsFromConfigs($configs = array(), $prefix)
+    public function getHttpConstantsFromConfigs($configs = array(), $prefix = null)
     {
         $arr = array();
         if ($prefix != null && is_array($configs)) {


### PR DESCRIPTION
Fixes "Required parameter $prefix follows optional parameter $configs"